### PR TITLE
Do not cache ruby-advisory-db

### DIFF
--- a/.github/workflows/audit_dependencies.yml
+++ b/.github/workflows/audit_dependencies.yml
@@ -22,16 +22,5 @@ jobs:
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-      - name: Restore ruby-advisory-db cache if possible. Cache ruby-advisory-db if the job succeeds. This is used by bundle-audit
-        uses: actions/cache@v2
-        env:
-          cache-name: cache_ruby-advisory-db
-        with:
-          # Details on how ruby-advisory-db is storing security advisories: https://github.com/rubysec/ruby-advisory-db#directory-structure
-          path: ~/.local/share/ruby-advisory-db/gems/
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/*.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.cache-name }}-
-
       - name: Audit dependencies
         run: bin/audit_dependencies


### PR DESCRIPTION
It's not faster than downloading ruby-advisory-db, it takes 1-2 seconds in both cases.