### PR TITLE
Render validation errors directly under their field

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,9 @@ gem "view_component"
 # Catch unsafe database migrations in development
 gem "strong_migrations"
 
+# Read, write, modify, and query XML/HTML documents
+gem "nokogiri"
+
 group :development, :test do
   # Analyze code for security vulnerabilities
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,6 +306,7 @@ DEPENDENCIES
   factory_bot_rails
   importmap-rails
   jbuilder
+  nokogiri
   puma
   pundit
   rails

--- a/app/lib/render_validation_errors.rb
+++ b/app/lib/render_validation_errors.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# A field with validation errors is highlighted in red and those errors are displayed directly under the field
+# Implementation inspired by https://www.jorgemanrubia.com/2019/02/16/form-validations-with-html5-and-modern-rails/
+class RenderValidationErrors
+  def initialize(html_tag, record, view_context)
+    @html_tag = html_tag
+    @record = record
+    @view_context = view_context
+    @field = Nokogiri::HTML.fragment(html_tag).at("input,select,textarea")
+  end
+
+  def call
+    # Only fields possibly have validation errors, so we return the HTML tag since it's not a field
+    return @html_tag unless @field
+
+    # The field doesn't have a validation error, so we return its HTML
+    return @html_tag if attribute_error_messages.empty?
+
+    # Any CSS class matching the regular expression is replaced by a space, to avoid having two CSS classes without a
+    # space between them
+    @field["class"] = "#{(@field['class'] || '').gsub(regex, ' ')} border-solid border-2 border-red-700".squeeze(" ")
+
+    # rubocop:disable Rails/OutputSafety
+    # The CSS classes of the field were changed, but it's not user input, so it's safe.
+    @field.to_s.html_safe.concat(
+      @view_context.content_tag(:p,
+                                class: "bg-red-50 text-red-700 px-3 py-2 font-medium rounded-lg mt-3 col-span-full") do
+        attribute_error_messages.join(", ")
+      end
+    )
+    # rubocop:enable Rails/OutputSafety
+  end
+
+  private
+
+  # Fetch all error messages for the record attribute (if it has any error...)
+  def attribute_error_messages
+    @attribute_error_messages ||= begin
+      attribute = @field.attributes["name"].value[/\[(?<name>.*)\]/, :name]
+      @record.errors.full_messages_for(attribute)
+    end
+  end
+
+  # CSS classes like `border`, `border-black`, and `border-gray-200` will match the regular expression
+  def regex
+    /
+      \s? # a space or nothing
+      border # the word `border`
+      (-?\w*)* # with or without dashes, followed by any amount of letter, number or underscore
+      \s? # a space or nothing
+    /x # free-spacing mode
+  end
+end

--- a/app/views/plants/_form.html.erb
+++ b/app/views/plants/_form.html.erb
@@ -1,14 +1,8 @@
 <%= form_with(model: plant, class: "contents") do |form| %>
   <% if plant.errors.any? %>
-    <div id="error_explanation" class="bg-red-50 text-red-700 px-3 py-2 font-medium rounded-lg mt-3">
-      <%= render HeadingComponent.new(2).with_content("#{pluralize(plant.errors.count, 'error')} prohibited this plant from being saved:") %>
-
-      <ul>
-        <% plant.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
+    <%= render HeadingComponent.new(2, extra_css_classes: "bg-red-50 text-red-700 px-3 py-2 font-medium rounded-lg mt-3") do %>
+      <%= "#{pluralize(plant.errors.count, 'error')} prohibited this plant from being saved." %>
+    <% end %>
   <% end %>
 
   <div class="my-5">

--- a/config/initializers/action_view_field_error_proc.rb
+++ b/config/initializers/action_view_field_error_proc.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Change how validation errors in forms are rendered
+# Details on this configuration at https://guides.rubyonrails.org/configuring.html#config-action-view-field-error-proc
+# Passing a Proc is needed, but we're calling a class to easily test this code
+Rails.application.configure do
+  config.action_view.field_error_proc = proc { |html_tag, tag_instance|
+    RenderValidationErrors.new(html_tag, tag_instance.object, self).call
+  }
+end

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -5,7 +5,8 @@ module.exports = {
     './app/helpers/**/*.rb',
     './app/javascript/**/*.js',
     './app/views/**/*.{erb,haml,html,slim}',
-    './app/components/**/*' // Both Ruby and template files, since inline components may also include Taildwind CSS classes
+    './app/components/**/*', // Both Ruby and template files, since inline components may also include Taildwind CSS classes
+    './app/lib/render_validation_errors.rb' // Generates HTML for validation errors in forms
   ],
   theme: {
     extend: {

--- a/spec/lib/render_validation_errors_spec.rb
+++ b/spec/lib/render_validation_errors_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RenderValidationErrors do
+  describe "call" do
+    subject(:result) { described_class.new(html_tag, record, view_context).call }
+
+    # Calling `valid?` on an instance of fake_model triggers the validations and generate validation errors if necessary
+    let(:fake_model) do
+      Class.new do
+        include ActiveModel::Model
+
+        def self.name
+          "FakeModel"
+        end
+
+        attr_accessor :my_attribute
+
+        validates :my_attribute, presence: true, length: { minimum: 3 }
+      end
+    end
+    let(:view_context) { ActionController::Base.new.view_context }
+
+    context "when passing a HTML tag which does not contain an input, select or textarea" do
+      let(:html_tag) { "<label for='something'>Something</label>" }
+      let(:record) { fake_model.new.tap(&:valid?) }
+
+      it "returns the HTML tag" do
+        expect(result).to eq(html_tag)
+      end
+    end
+
+    context "when passing a HTML tag which contains an input for a model attribute with validation errors" do
+      let(:html_tag) do
+        '<input type="text" value="" name="fake_model[my_attribute]" id="fake_model_my_attribute" ' \
+          'class="w-full border border-dashed border-gray-200">'
+      end
+      let(:record) { fake_model.new.tap(&:valid?) }
+
+      it "return the HTML tag highlighted in red with a paragraph containing the validation error messages" do
+        # rubocop:disable Layout/LineLength
+        # Free-spacing mode for regular expression is somehow not taken into account in RSpec...
+        expect(result).to match(%r{<input.*class="w-full border-solid border-2 border-red-700"><p.*>My attribute can&#39;t be blank, My attribute is too short \(minimum is 3 characters\)</p>})
+        # rubocop:enable Layout/LineLength
+      end
+    end
+
+    context "when passing a HTML tag which contains an input for a model attribute without validation errors" do
+      let(:html_tag) { "<input type='text' value='' name='fake_model[my_attribute]' id='fake_model_my_attribute'>" }
+      let(:record) { fake_model.new(my_attribute: "123").tap(&:valid?) }
+
+      it "returns the HTML tag" do
+        expect(result).to eq(html_tag)
+      end
+    end
+
+    context "when passing a HTML tag which contains a textarea for a model attribute with validation errors" do
+      let(:html_tag) do
+        '<textarea name="fake_model[my_attribute]" id="fake_model_my_attribute" ' \
+          'class="w-full border border-dashed border-gray-200"></textarea>'
+      end
+      let(:record) { fake_model.new.tap(&:valid?) }
+
+      it "return the HTML tag highlighted in red with a paragraph containing the validation error messages" do
+        # rubocop:disable Layout/LineLength
+        # Free-spacing mode for regular expression is somehow not taken into account in RSpec...
+        expect(result).to match(%r{<textarea.*class="w-full border-solid border-2 border-red-700"></textarea><p.*>My attribute can&#39;t be blank, My attribute is too short \(minimum is 3 characters\)</p>})
+        # rubocop:enable Layout/LineLength
+      end
+    end
+
+    context "when passing a HTML tag which contains a textarea for a model attribute without validation errors" do
+      let(:html_tag) do
+        '<textarea name="fake_model[my_attribute]" id="fake_model_my_attribute" ' \
+          'class="w-full border border-dashed border-gray-200"></textarea>'
+      end
+      let(:record) { fake_model.new(my_attribute: "123").tap(&:valid?) }
+
+      it "returns the HTML tag" do
+        expect(result).to eq(html_tag)
+      end
+    end
+
+    context "when passing a HTML tag which contains a select for a model attribute with validation errors" do
+      let(:html_tag) do
+        '<select name="fake_model[my_attribute]" id="fake_model_my_attribute" ' \
+          'class="w-full border border-dashed border-gray-200"><option value="1">1</option></select>'
+      end
+      let(:record) { fake_model.new.tap(&:valid?) }
+
+      it "return the HTML tag highlighted in red with a paragraph containing the validation error messages" do
+        # rubocop:disable Layout/LineLength
+        # Free-spacing mode for regular expression is somehow not taken into account in RSpec...
+        expect(result).to match(%r{<select.*class="w-full border-solid border-2 border-red-700">.*</select><p.*>My attribute can&#39;t be blank, My attribute is too short \(minimum is 3 characters\)</p>})
+        # rubocop:enable Layout/LineLength
+      end
+    end
+
+    context "when passing a HTML tag which contains a select for a model attribute without validation errors" do
+      let(:html_tag) do
+        '<select name="fake_model[my_attribute]" id="fake_model_my_attribute" ' \
+          'class="w-full border border-dashed border-gray-200"><option value="1">1</option></select>'
+      end
+      let(:record) { fake_model.new(my_attribute: "123").tap(&:valid?) }
+
+      it "returns the HTML tag" do
+        expect(result).to eq(html_tag)
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this, validation errors are rendered right under the field which caused them. For users, addressing those errors is therefore easier.

Set Nokogiri as a direct dependency. It was already installed as a dependency from actiontext.