### PR TITLE
Use db:test:prepare instead of db:reset in bin/run_specs

### DIFF
--- a/bin/run_specs
+++ b/bin/run_specs
@@ -3,14 +3,8 @@
 # Ensure we're running in the test environment
 export RAILS_ENV=test
 
-echo "Resetting test database"
-bundle exec rake db:reset
-
-# This is needed only when running in GitHub Actions (where the environment variable CI is always set)
-if [[ "$CI" = true ]]; then
-  echo "Precompile assets" # to prevent the error `ActionView::Template::Error: The asset "tailwind.css" is not present in the asset pipeline.`
-  bundle exec rake assets:precompile
-fi
+echo "Checking for pending migrations and loading the database schema in the test database"
+bundle exec rake db:test:prepare
 
 echo "Running specs"
 bundle exec rspec "$@" # all arguments passed to this script are passed to RSpec


### PR DESCRIPTION
In the gem tailwindcss-rails, the Tailwind CSS assets are built when executing the rake task `db:test:prepare`.

Details here:
https://github.com/rails/tailwindcss-rails/blob/47f636b12880dc07c9c6210a7c71658186844c5f/lib/tasks/build.rake#L20