### PR TITLE
Setup and use responders gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,9 @@ gem "pundit"
 gem "rails"
 # Use Redis adapter to run Action Cable in production
 # gem "redis"
+# Dry up Rails controllers with a set of responders (respond_to, respond_with)
+# github + ref: For flash messages to work with Turbo... Until a new gem version is cut
+gem "responders", github: "heartcombo/responders", ref: "56d00ac"
 # Authentication framework
 gem "rodauth-rails"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/heartcombo/responders.git
+  revision: 56d00ac8894b38de9eff177cb50dda110ff79440
+  ref: 56d00ac
+  specs:
+    responders (3.0.1)
+      actionpack (>= 5.2)
+      railties (>= 5.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -329,6 +338,7 @@ DEPENDENCIES
   puma
   pundit
   rails
+  responders!
   rodauth-rails
   rspec
   rspec-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+require "application_responder"
+
 class ApplicationController < ActionController::Base
+  #---- Start of configuration from responders gem
+  self.responder = ApplicationResponder
+  respond_to :html
+  # Prevent execution of controllers actions by raising `UnknownFormat` exception if the requested format was not
+  # configured through the class level `respond_to`
+  before_action :verify_requested_format!
+  #---- End of configuration from responders gem
+
   include Pundit::Authorization
 end

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class PlantsController < ApplicationController
+  respond_to :html, :json
   before_action :set_plant, only: %i[show edit update destroy]
 
   # GET /plants or /plants.json
@@ -21,48 +22,23 @@ class PlantsController < ApplicationController
 
   # POST /plants or /plants.json
   def create
-    @plant = Plant.new(plant_params)
+    @plant = Plant.create(plant_params)
 
-    respond_to do |format|
-      if @plant.save
-        format.html { redirect_to plant_url(@plant), notice: "Plant was successfully created." }
-        format.json { render :show, status: :created, location: @plant }
-      else
-        format.html do
-          flash.now[:alert] =
-            "#{view_context.pluralize(@plant.errors.count, 'error')} prohibited this plant from being created."
-          render :new, status: :unprocessable_entity
-        end
-        format.json { render json: @plant.errors, status: :unprocessable_entity }
-      end
-    end
+    respond_with(@plant)
   end
 
   # PATCH/PUT /plants/1 or /plants/1.json
   def update
-    respond_to do |format|
-      if @plant.update(plant_params)
-        format.html { redirect_to plant_url(@plant), notice: "Plant was successfully updated." }
-        format.json { render :show, status: :ok, location: @plant }
-      else
-        format.html do
-          flash.now[:alert] =
-            "#{view_context.pluralize(@plant.errors.count, 'error')} prohibited this plant from being updated."
-          render :edit, status: :unprocessable_entity
-        end
-        format.json { render json: @plant.errors, status: :unprocessable_entity }
-      end
-    end
+    @plant.update(plant_params)
+
+    respond_with(@plant)
   end
 
   # DELETE /plants/1 or /plants/1.json
   def destroy
     @plant.destroy
 
-    respond_to do |format|
-      format.html { redirect_to plants_url, notice: "Plant was successfully destroyed." }
-      format.json { head :no_content }
-    end
+    respond_with(@plant)
   end
 
   private

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,9 @@ module Garden
 
       # Do not generate RSpec specs for routes since the vast majority of routes are RESTful
       generator.test_framework :rspec, routing_specs: false
+
+      # Use the responders controller from the responders gem
+      generator.scaffold_controller :responders_controller
     end
 
     # View components

--- a/config/locales/responders.en.yml
+++ b/config/locales/responders.en.yml
@@ -1,0 +1,12 @@
+en:
+  flash:
+    actions:
+      create:
+        notice: "%{resource_name} was successfully created."
+        alert: "%{resource_name} could not be created."
+      update:
+        notice: "%{resource_name} was successfully updated."
+        alert: "%{resource_name} could not be updated."
+      destroy:
+        notice: "%{resource_name} was successfully destroyed."
+        alert: "%{resource_name} could not be destroyed."

--- a/lib/application_responder.rb
+++ b/lib/application_responder.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ApplicationResponder < ActionController::Responder
+  # Sets the flash message based on the controller action and resource status.
+  # For instance, if you do: `respond_with(@post)` on a POST request and the resource `@post` does not contain errors,
+  # it will automatically set the flash message to "Post was successfully created".
+  # Change the flash messages in config/locales/responders.en.yml
+  include Responders::FlashResponder
+  # Automatically adds Last-Modified headers to API requests. This allows clients to easily query the server if a
+  # resource changed and if the client tries to retrieve a resource that has not been modified, it returns
+  # not_modified status
+  include Responders::HttpCacheResponder
+
+  # Redirects resources to the collection path (index action) instead
+  # of the resource path (show action) for POST/PUT/DELETE requests.
+  # include Responders::CollectionResponder
+end

--- a/spec/requests/plants_spec.rb
+++ b/spec/requests/plants_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "/plants", type: :request do
       it "renders errors" do
         post plants_url, params: { plant: invalid_attributes }
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(response.body).to include("errors prohibited this plant from being created.")
+        expect(response.body).to include("Plant could not be created.")
       end
     end
   end
@@ -129,7 +129,7 @@ RSpec.describe "/plants", type: :request do
         plant = Plant.create! valid_attributes
         patch plant_url(plant), params: { plant: invalid_attributes }
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(response.body).to include("errors prohibited this plant from being updated.")
+        expect(response.body).to include("Plant could not be updated.")
       end
     end
   end


### PR DESCRIPTION
All changes generated by `bin/rails g responders:install`, except for PlantsController and `before_action :verify_requested_format!` in ApplicationController.